### PR TITLE
Add BepInIncompatibility for Magnificus Mod and Grimora mod

### DIFF
--- a/P03KayceeRun.cs
+++ b/P03KayceeRun.cs
@@ -12,6 +12,8 @@ namespace Infiniscryption.P03KayceeRun
 {
     [BepInPlugin(PluginGuid, PluginName, PluginVersion)]
     [BepInDependency("cyantist.inscryption.api")]
+    [BepInIncompatibility("silenceman.inscryption.magnificusmod")]
+    [BepInIncompatibility("arackulele.inscryption.grimoramod")]
     public class P03Plugin : BaseUnityPlugin
     {
 


### PR DESCRIPTION
A few people have come into the Inscryption modding discord asking why P03 kc's mod breaks when they have it installed with Magnificus Mod and Grimora Mod D: 

As of now, with more than one of those three mods installed, something usually ends up breaking mid-game with a vague error, making debugging the issues of those people difficult. However, BepInIncompatibility generates a much cleaner error message, making things much easier to debug. I didn't even know BepInEx had this until earlier today, but I thought it might come in handy sdlkjfsldkjf (Inscryption will still launch, but it prevents the plugin from loading if an incompatible plugin is installed)

Here's hoping the plugin GUIDs for magnificus mod and grimora mod never change!!